### PR TITLE
add vue prototype helper for cloudinary core js library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6838,7 +6838,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pify": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "vue-template-compiler": "^2.6.11"
   },
   "dependencies": {
+    "cloudinary-core": "^2.8.2",
     "cloudinary-vue": "^1.0.1",
     "current-script-polyfill": "^1.0.0"
   }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,11 @@
 import Vue from "vue";
+import CloudinaryCore from "cloudinary-core";
 import CloudinaryComponent from "./components/CloudinaryComponent.vue";
 import Cloudinary, {CldImage, CldTransformation} from "cloudinary-vue";
+
+Vue.prototype.$cloudinaryCore = new CloudinaryCore.Cloudinary({
+    cloud_name: "flaunt-your-site", secure: true
+});
 
 Vue.use(Cloudinary, {
     configuration: {

--- a/resources/js/components/ImageStage.vue
+++ b/resources/js/components/ImageStage.vue
@@ -67,15 +67,19 @@
                 @angleClick="setAngle"
             ></edit-tools>
         </div>
+
+        <watch-image-stage></watch-image-stage>
     </div>
 </template>
 
 <script>
 import EditTools from "./EditTools.vue"
+import WatchImageStage from "./WatchImageStage.vue"
 
 export default {
     components: {
         EditTools,
+        WatchImageStage,
     },
     props: {
         image: {
@@ -102,7 +106,6 @@ export default {
         }
     },
     mounted() {
-        this.watchCldImage()
         this.getCanvasInfo()
         this.getImageInfo()
         this.reflectOrientation()
@@ -293,14 +296,6 @@ export default {
             } else {
                 this.dpiWarning = false
             }
-        },
-        watchCldImage() {
-            this.$watch("$refs.cldImage.imageAttrs.src", {
-                handler(newUrl, oldUrl) {
-                    this.image.gme_final_url = newUrl
-                },
-                immediate: false,
-            })
         },
         setBorder(border) {
             this.$root.processingImage = true

--- a/resources/js/components/WatchImageStage.vue
+++ b/resources/js/components/WatchImageStage.vue
@@ -1,0 +1,55 @@
+<script>
+export default {
+  render() {
+    if (this.$parent.$options._componentTag !== "image-stage") return;
+
+    this.watchCldImageTrans();
+  },
+  methods: {
+    watchCldImageTrans() {
+      this.$watch("$parent.$refs.cldImage.transformations", {
+        handler(newValue, oldValue) {
+          // Grab canvas transformation obj
+          const canvasTrans = newValue.filter(
+            transformation => !transformation.overlay
+          );
+
+          // Convert to vanilla object to mutate overlay trans
+          // TODO: Here would calcuate the size of the canvas relative
+          // relative to the images original width and height. For now I'm
+          // setting it to match image width/height to mimic 'fullFrame' for testing
+          let canvasObj = { ...canvasTrans[0] };
+          canvasObj.width = this.$parent.image.width;
+          canvasObj.height = this.$parent.image.height;
+
+          // Grab overlay transformation obj
+          const overlayTrans = newValue.filter(
+            transformation => transformation.overlay
+          );
+
+          // Convert overlayTrans to vanilla object to mutate
+          const overlayObj = { ...overlayTrans[0] };
+          // TODO: I've noticed that if this.$parent.image.width/this.$parent.image.height
+          // are too large, Cloudinary may not render image.
+          overlayObj.width = this.$parent.image.width;
+          overlayObj.height = this.$parent.image.height;
+
+          // Build new object containing both the canvasTrans, overlayTrans
+          const newObj = [{ ...canvasObj }, { ...overlayObj }];
+
+          // Create final image url using Cloudinary core JS lib
+          // TODO: Should we be hard-coding "assets/16_20_bg_khaqct.jpg"?
+          this.$parent.image.gme_final_url = this.$cloudinaryCore
+            .imageTag("assets/16_20_bg_khaqct.jpg", { transformation: newObj })
+            .getAttr("src");
+        },
+        deep: true,
+        immediate: false
+      });
+    }
+  }
+};
+</script>
+
+<style>
+</style>


### PR DESCRIPTION
Added new npm package. You'll need to delete node_modules, package-lock.json, then rerun npm install.

Extracted all logic that is "watching" for final url changes to separate helper component. The ImageStage component should just handle the editor logic.  